### PR TITLE
Missing disposes on "Stop"

### DIFF
--- a/SimpleUdp/UdpEndpoint.cs
+++ b/SimpleUdp/UdpEndpoint.cs
@@ -182,10 +182,9 @@ namespace SimpleUdp
         /// </summary>
         public void Stop()
         {
-            if (_Socket != null)
-            {
-                _Socket.Close();
-            }
+            _UdpClient?.Dispose();
+            _Socket?.Close();
+            _Socket?.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
Udp client and socket must be disposed on stop, else an SocketException will be faced on re-start, saying "Binding to IP/port only allowed once"