### PR TITLE
Send data with offset and size

### DIFF
--- a/Node/Node.csproj
+++ b/Node/Node.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleUdp/SimpleUdp.csproj
+++ b/SimpleUdp/SimpleUdp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Version>1.2.0</Version>
     <OutputType>Library</OutputType>
 	<ApplicationIcon>assets\icon.ico</ApplicationIcon>

--- a/SimpleUdp/SimpleUdp.csproj
+++ b/SimpleUdp/SimpleUdp.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caching.dll" Version="1.4.0.1" />
+    <PackageReference Include="Caching.dll" Version="2.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimpleUdp/SimpleUdp.xml
+++ b/SimpleUdp/SimpleUdp.xml
@@ -119,7 +119,13 @@
         </member>
         <member name="M:SimpleUdp.UdpEndpoint.#ctor(System.Net.Sockets.UdpClient)">
             <summary>
-            Instantiate the UDP endpoint.
+            Use existing Socket from UdpClient.
+            If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'Start()'.
+            </summary>
+        </member>
+        <member name="M:SimpleUdp.UdpEndpoint.#ctor(System.Net.Sockets.Socket)">
+            <summary>
+            Use existing Socket.
             If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'Start()'.
             </summary>
         </member>
@@ -138,6 +144,7 @@
             <summary>
             Start the UDP listener to receive datagrams.  Before calling this method, set the 'DatagramReceived' event.
             </summary>
+            <exception cref="T:System.InvalidOperationException">Already started</exception>
         </member>
         <member name="M:SimpleUdp.UdpEndpoint.Stop">
             <summary>

--- a/SimpleUdp/SimpleUdp.xml
+++ b/SimpleUdp/SimpleUdp.xml
@@ -105,10 +105,23 @@
         <member name="M:SimpleUdp.UdpEndpoint.#ctor(System.String,System.Int32)">
             <summary>
             Instantiate the UDP endpoint.
-            If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'StartServer()'.
+            If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'Start()'.
             </summary>
-            <param name="ip">Local IP address.</param>
+            <param name="hostname">Local hostname.</param>
             <param name="port">Local port number.</param>
+        </member>
+        <member name="M:SimpleUdp.UdpEndpoint.#ctor(System.Int32)">
+            <summary>
+            Instantiate the UDP endpoint.
+            If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'Start()'.
+            </summary>
+            <param name="port">Local port number.</param>
+        </member>
+        <member name="M:SimpleUdp.UdpEndpoint.#ctor(System.Net.Sockets.UdpClient)">
+            <summary>
+            Instantiate the UDP endpoint.
+            If you wish to also receive datagrams, set the 'DatagramReceived' event and call 'Start()'.
+            </summary>
         </member>
         <member name="M:SimpleUdp.UdpEndpoint.Dispose">
             <summary>

--- a/SimpleUdp/SimpleUdp.xml
+++ b/SimpleUdp/SimpleUdp.xml
@@ -151,6 +151,16 @@
             <param name="data">Bytes.</param>
             <param name="ttl">Time to live, the maximum number of routers the packet is allowed to traverse.  Minimum is 0, default is 64.</param>
         </member>
+        <member name="M:SimpleUdp.UdpEndpoint.SendOffset(System.String,System.Int32,System.Byte[],System.Int32,System.Int32,System.Int16)">
+            <summary>
+            Send a datagram to the specific IP address and UDP port with specific offset and size.
+            This will throw a SocketException if the report UDP port is unreachable.
+            </summary>
+            <param name="ip">IP address.</param>
+            <param name="port">Port.</param>
+            <param name="data">Bytes.</param>
+            <param name="ttl">Time to live, the maximum number of routers the packet is allowed to traverse.  Minimum is 0, default is 64.</param>
+        </member>
         <member name="M:SimpleUdp.UdpEndpoint.SendAsync(System.String,System.Int32,System.String,System.Int16)">
             <summary>
             Send a datagram asynchronously to the specific IP address and UDP port.
@@ -164,6 +174,16 @@
         <member name="M:SimpleUdp.UdpEndpoint.SendAsync(System.String,System.Int32,System.Byte[],System.Int16)">
             <summary>
             Send a datagram asynchronously to the specific IP address and UDP port.
+            This will throw a SocketException if the report UDP port is unreachable.
+            </summary>
+            <param name="ip">IP address.</param>
+            <param name="port">Port.</param>
+            <param name="data">Bytes.</param> 
+            <param name="ttl">Time to live, the maximum number of routers the packet is allowed to traverse.  Minimum is 0, default is 64.</param>
+        </member>
+        <member name="M:SimpleUdp.UdpEndpoint.SendOffsetAsync(System.String,System.Int32,System.Byte[],System.Int32,System.Int32,System.Int16)">
+            <summary>
+            Send a datagram asynchronously to the specific IP address and UDP port with specific offset and size.
             This will throw a SocketException if the report UDP port is unreachable.
             </summary>
             <param name="ip">IP address.</param>

--- a/SimpleUdp/UdpEndpoint.cs
+++ b/SimpleUdp/UdpEndpoint.cs
@@ -83,7 +83,7 @@ namespace SimpleUdp
         private UdpClient _UdpClient = null;
         private AsyncCallback _ReceiveCallback = null;
 
-        private LRUCache<string, Socket> _RemoteSockets = new LRUCache<string, Socket>(100, 1, false);
+        private LRUCache<string, Socket> _RemoteSockets = new LRUCache<string, Socket>(100, 1, null, false);
          
         private SemaphoreSlim _SendLock = new SemaphoreSlim(1, 1);
 


### PR DESCRIPTION
\+ use less memory and cpu when sending a range of a large array (no copying array)
\+ update dep Caching.dll to latest stable
\- no compatibility with net461
\- cannot be started after stop

• no API modifications, new funcioonality (no code modifications needed after update)
• switch to net standart 2.0 (instead of 2.1)